### PR TITLE
Прекращение атаки NPC

### DIFF
--- a/Assets/Scripts/ECS/CharacterAttachment/PrepareControlledNpcSystem.cs
+++ b/Assets/Scripts/ECS/CharacterAttachment/PrepareControlledNpcSystem.cs
@@ -1,0 +1,29 @@
+using Scellecs.Morpeh;
+using Unity.IL2CPP.CompilerServices;
+
+[Il2CppSetOption(Option.NullChecks, false)]
+[Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+[Il2CppSetOption(Option.DivideByZeroChecks, false)]
+public sealed class PrepareControlledNpcSystem : CustomUpdateSystem {
+    Event<AttachedToCharacterEvent> _attachEvt;
+    Event<PrimaryActionEvent> _primEvt;
+
+    public override void OnAwake()
+    {
+        _attachEvt = World.GetEvent<AttachedToCharacterEvent>();
+        _primEvt = World.GetEvent<PrimaryActionEvent>();
+    }
+
+    public override void OnUpdate(float deltaTime) {
+        int idx = _attachEvt.publishedChanges.length - 1;
+        if (idx < 0)
+            return;
+
+        var evt = _attachEvt.publishedChanges.data[idx];
+        if (!World.TryGetEntity(evt.controlledId, out Entity e) || e.IsNullOrDisposed())
+            return;
+
+        if (e.Has<AttackTargetComponent>())
+            _primEvt.NextFrame(new PrimaryActionEvent { actorId = e.ID, activated = false });
+    }
+}

--- a/Assets/Scripts/ECS/CharacterAttachment/PrepareControlledNpcSystem.cs.meta
+++ b/Assets/Scripts/ECS/CharacterAttachment/PrepareControlledNpcSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 234142e3c22ff5148a71099fff5b0ae4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 493eb45005e8adb45b6b2cb31be411e9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Services/Factories/SystemsGroups/CharacterAttachmentSystemsFactory.cs
+++ b/Assets/Scripts/Services/Factories/SystemsGroups/CharacterAttachmentSystemsFactory.cs
@@ -21,7 +21,8 @@ public class CharacterAttachmentSystemsFactory : ISystemsGroupFactory
     {
         List<ISystem> systems = new List<ISystem>
         {
-            new CharacterAttachmentSystem(_controls, _controlled, _camMonitor)
+            new CharacterAttachmentSystem(_controls, _controlled, _camMonitor),
+            new PrepareControlledNpcSystem()
         };
 
         var group = world.CreateSystemsGroup();


### PR DESCRIPTION
Теперь при перехвате игроком управления над персонажем у последнего корректно завершается текущая атака, после чего уже игрок может начать новую. (багфикс #5 )