### PR TITLE
Усовершенствован обход союзников

### DIFF
--- a/Assets/Prefabs/TestMonster.prefab
+++ b/Assets/Prefabs/TestMonster.prefab
@@ -231,7 +231,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  - {fileID: 2100000, guid: 768aa95b7fa0f2943afbc2f4ca42ba79, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefabs/TestSoldier.prefab
+++ b/Assets/Prefabs/TestSoldier.prefab
@@ -63,7 +63,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 13f05a82633a15c48badb6edd758cc36, type: 2}
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -341,6 +341,99 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 8361033423392509693}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &473291053
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 202436621818752497, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3107546673308750404, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3597951128387492086, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175716288218539776, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920589667256189663, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7193201995071429587, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_Name
+      value: Soldier (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8907113512155733533, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 85a05b5c8014ad345aacf587bf72b095, type: 3}
 --- !u!1 &488528683
 GameObject:
   m_ObjectHideFlags: 0
@@ -488,6 +581,21 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1141955973715455964, guid: bfb0a78d2e3ce56449b7acedf227edd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1317051838106539105, guid: bfb0a78d2e3ce56449b7acedf227edd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342834560262264113, guid: bfb0a78d2e3ce56449b7acedf227edd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2164000167951085048, guid: bfb0a78d2e3ce56449b7acedf227edd6,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -542,6 +650,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Monster
+      objectReference: {fileID: 0}
+    - target: {fileID: 8184270240985061819, guid: bfb0a78d2e3ce56449b7acedf227edd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2656,6 +2769,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7104707985755204810, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7104707985755204810, guid: 85a05b5c8014ad345aacf587bf72b095,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
     - target: {fileID: 7193201995071429587, guid: 85a05b5c8014ad345aacf587bf72b095,
         type: 3}
       propertyPath: m_Name
@@ -2684,6 +2807,7 @@ SceneRoots:
   - {fileID: 627389581}
   - {fileID: 1661831073}
   - {fileID: 9159083516256890563}
+  - {fileID: 473291053}
   - {fileID: 694190650}
   - {fileID: 488528684}
   - {fileID: 917841565}

--- a/Assets/Scripts/ECS/AI/AgentAspect.cs
+++ b/Assets/Scripts/ECS/AI/AgentAspect.cs
@@ -6,35 +6,27 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.NullChecks, false)]
 [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-public struct MobileAgentAspect : IAspect, IFilterExtension
+public struct AgentAspect : IAspect, IFilterExtension
 {
     public Entity Entity { get; set; }
 
     public ref BodyComponent Body => ref _bodyStash.Get(Entity);
-    public ref MovementComponent Movement => ref _movementStash.Get(Entity);
     public ref ActorComponent Actor => ref _actorStash.Get(Entity);
-    public ref AgentPathComponent Path => ref _pathStash.Get(Entity);
 
     Stash<BodyComponent> _bodyStash;
-    Stash<MovementComponent> _movementStash;
     Stash<ActorComponent> _actorStash;
-    Stash<AgentPathComponent> _pathStash;
 
     public void OnGetAspectFactory(World world)
     {
         _bodyStash = world.GetStash<BodyComponent>();
-        _movementStash = world.GetStash<MovementComponent>();
         _actorStash = world.GetStash<ActorComponent>();
-        _pathStash = world.GetStash<AgentPathComponent>();
     }
 
     public FilterBuilder Extend(FilterBuilder builder)
     {
         return builder.
             With<BodyComponent>().
-            With<MovementComponent>().
             With<ActorComponent>().
-            With<AgentPathComponent>().
             Without<PlayerComponent>();
     }
 }

--- a/Assets/Scripts/ECS/AI/AgentAspect.cs.meta
+++ b/Assets/Scripts/ECS/AI/AgentAspect.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
-guid: 1c92439139549f045b67847e067eb3e7
+guid: c8727907ca9ddd8409b26139cf0414c0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: f9ee0ee02230c45419322bc79d330d72, type: 3}
+  icon: {instanceID: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scripts/ECS/AI/Navigation/AgentPathUpdateSystem.cs
+++ b/Assets/Scripts/ECS/AI/Navigation/AgentPathUpdateSystem.cs
@@ -7,22 +7,22 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class AgentPathUpdateSystem : CustomUpdateSystem {
-    AspectFactory<MobileAgentAspect> _agentFactory;
+    AspectFactory<AgentAspect> _agentFactory;
     Filter _agents;
 
     public override void OnAwake()
     {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
-        _agents = World.Filter.Extend<MobileAgentAspect>().Build();
+        _agentFactory = World.GetAspectFactory<AgentAspect>();
+        _agents = World.Filter.Extend<AgentAspect>().With<AgentPathComponent>().Build();
     }
 
     public override void OnUpdate(float deltaTime)
     {
         foreach(Entity e in _agents)
         {
-            var mobileAgent = _agentFactory.Get(e);
-            var body = mobileAgent.Body;
-            ref var agentPath = ref mobileAgent.Path;
+            var agent = _agentFactory.Get(e);
+            var body = agent.Body;
+            ref var agentPath = ref e.GetComponent<AgentPathComponent>();
 
             float curTime = Time.time;
             if (agentPath.lastUpdatePath + agentPath.pathUpdateInterval > curTime)

--- a/Assets/Scripts/ECS/AI/Strategies/Attack Target/AttackTargetSystem.cs
+++ b/Assets/Scripts/ECS/AI/Strategies/Attack Target/AttackTargetSystem.cs
@@ -7,17 +7,12 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class AttackTargetSystem : CustomUpdateSystem
 {
-    AspectFactory<MobileAgentAspect> _agentFactory;
     Filter _attackers;
     Event<PrimaryActionEvent> _primEvt;
 
     public override void OnAwake() {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
         _attackers = World.Filter.
-            Extend<MobileAgentAspect>().
-            With<TargetObserverComponent>().
             With<AttackTargetComponent>().
-            With<ActiveEquipment>().
             Build();
         
         _primEvt = World.GetEvent<PrimaryActionEvent>();

--- a/Assets/Scripts/ECS/AI/Strategies/Attack Target/FromAttackerSystem.cs
+++ b/Assets/Scripts/ECS/AI/Strategies/Attack Target/FromAttackerSystem.cs
@@ -7,15 +7,15 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class FromAttackerSystem : CustomUpdateSystem
 {
-    AspectFactory<MobileAgentAspect> _agentFactory;
+    AspectFactory<AgentAspect> _agentFactory;
     Filter _attackers;
     Event<PrimaryActionEvent> _primEvt;
 
     public override void OnAwake()
     {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
+        _agentFactory = World.GetAspectFactory<AgentAspect>();
         _attackers = World.Filter.
-            Extend<MobileAgentAspect>().
+            Extend<AgentAspect>().
             With<TargetObserverComponent>().
             With<AttackTargetComponent>().
             Build();
@@ -29,7 +29,7 @@ public sealed class FromAttackerSystem : CustomUpdateSystem
             var mobileAgent = _agentFactory.Get(e);
             var target = e.GetComponent<TargetObserverComponent>();
 
-            if (target.IsAcquired)
+            if (target.isInSight)
             {
                 float distance = (target.transform.position - mobileAgent.Body.transform.position).magnitude;
                 if (distance <= mobileAgent.Actor.config.AttackRange)

--- a/Assets/Scripts/ECS/AI/Strategies/Attack Target/ToAttackerSystem.cs
+++ b/Assets/Scripts/ECS/AI/Strategies/Attack Target/ToAttackerSystem.cs
@@ -7,14 +7,14 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class ToAttackerSystem : CustomUpdateSystem
 {
-    AspectFactory<MobileAgentAspect> _agentFactory;
+    AspectFactory<AgentAspect> _agentFactory;
     Filter _potentialAttackers;
 
     public override void OnAwake()
     {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
+        _agentFactory = World.GetAspectFactory<AgentAspect>();
         _potentialAttackers = World.Filter.
-            Extend<MobileAgentAspect>().
+            Extend<AgentAspect>().
             With<TargetObserverComponent>().
             Without<AttackTargetComponent>().
             Build();

--- a/Assets/Scripts/ECS/AI/Strategies/Detect Target/TargetAcquirementSystem.cs
+++ b/Assets/Scripts/ECS/AI/Strategies/Detect Target/TargetAcquirementSystem.cs
@@ -8,7 +8,7 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class TargetAcquirementSystem : CustomUpdateSystem
 {
-    AspectFactory<MobileAgentAspect> _agentFactory;
+    AspectFactory<AgentAspect> _agentFactory;
     Filter _targetAwareFilter;
     GroupRelationMatrix _relMatrix;
 
@@ -16,9 +16,9 @@ public sealed class TargetAcquirementSystem : CustomUpdateSystem
 
     public override void OnAwake()
     {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
+        _agentFactory = World.GetAspectFactory<AgentAspect>();
         _targetAwareFilter = World.Filter.
-            Extend<MobileAgentAspect>().
+            Extend<AgentAspect>().
             With<TargetObserverComponent>().
             Without<AttackTargetComponent>().
             Build();
@@ -38,7 +38,7 @@ public sealed class TargetAcquirementSystem : CustomUpdateSystem
         }
     }
 
-    private bool TryAcquireTarget(MobileAgentAspect mobileAgent, ref TargetObserverComponent target)
+    private bool TryAcquireTarget(AgentAspect mobileAgent, ref TargetObserverComponent target)
     {
         var actor = mobileAgent.Actor;
         foreach (Collider col in Physics.OverlapSphere(actor.eye.position, target.sightDistance, LayerMask.GetMask("Population")))

--- a/Assets/Scripts/ECS/AI/Strategies/Level Exploration/ExplorationSystem.cs
+++ b/Assets/Scripts/ECS/AI/Strategies/Level Exploration/ExplorationSystem.cs
@@ -7,13 +7,14 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class ExplorationSystem : CustomUpdateSystem
 {
-    AspectFactory<MobileAgentAspect> _agentFactory;
+    AspectFactory<AgentAspect> _agentFactory;
     Filter _explorers;
 
     public override void OnAwake() {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
+        _agentFactory = World.GetAspectFactory<AgentAspect>();
         _explorers = World.Filter.
-            Extend<MobileAgentAspect>().
+            Extend<AgentAspect>().
+            With<AgentPathComponent>().
             With<ExplorerComponent>().
             Build();
     }
@@ -24,17 +25,17 @@ public sealed class ExplorationSystem : CustomUpdateSystem
             var mobileAgent = _agentFactory.Get(e);
 
             var body = mobileAgent.Body;
-            ref var agent = ref mobileAgent.Path;
             ref var actor = ref mobileAgent.Actor;
+            ref var agentPath = ref e.GetComponent<AgentPathComponent>();
             ref var explorer = ref e.GetComponent<ExplorerComponent>();
 
-            if (agent.pathNodeIdx < 0 || agent.pathNodeIdx >= agent.path.Length)
+            if (agentPath.pathNodeIdx < 0 || agentPath.pathNodeIdx >= agentPath.path.Length)
                 actor.lookTarget = actor.eye.position + actor.eye.forward;
             else
-                actor.lookTarget = agent.path[agent.pathNodeIdx];
+                actor.lookTarget = agentPath.path[agentPath.pathNodeIdx];
 
             bool requiresTarget = explorer.targetZone == null;
-            bool reachedTarget = (agent.destination - body.transform.position).magnitude < 1f;
+            bool reachedTarget = (agentPath.destination - body.transform.position).magnitude < 1f;
 
             if (actor.currentZone == null || !requiresTarget && !reachedTarget)
                 continue;
@@ -42,7 +43,7 @@ public sealed class ExplorationSystem : CustomUpdateSystem
             float exploreRand = Random.Range(0f, 1f);
             bool stay = exploreRand > actor.config.ExplorationPenchant;
             explorer.targetZone = stay ? actor.currentZone : actor.currentZone.ChooseNextZone(actor.config.GroupId);
-            agent.destination = explorer.targetZone.GetRandomPoint();
+            agentPath.destination = explorer.targetZone.GetRandomPoint();
         }
     }
 }

--- a/Assets/Scripts/ECS/AI/Strategies/Level Exploration/ExplorerToPursuerSystem.cs
+++ b/Assets/Scripts/ECS/AI/Strategies/Level Exploration/ExplorerToPursuerSystem.cs
@@ -7,14 +7,14 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class ExplorerToPursuerSystem : CustomUpdateSystem
 {
-    AspectFactory<MobileAgentAspect> _agentFactory;
+    AspectFactory<AgentAspect> _agentFactory;
     Filter _explorersWithTarget;
 
     public override void OnAwake()
     {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
+        _agentFactory = World.GetAspectFactory<AgentAspect>();
         _explorersWithTarget = World.Filter.
-            Extend<MobileAgentAspect>().
+            Extend<AgentAspect>().
             With<ExplorerComponent>().
             With<TargetObserverComponent>().
             Build();

--- a/Assets/Scripts/ECS/AI/Strategies/Pursue Target/PursueTargetSystem.cs
+++ b/Assets/Scripts/ECS/AI/Strategies/Pursue Target/PursueTargetSystem.cs
@@ -7,15 +7,16 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class PursueTargetSystem : CustomUpdateSystem
 {
-    AspectFactory<MobileAgentAspect> _agentFactory;
+    AspectFactory<AgentAspect> _agentFactory;
     Filter _pursuers;
     Color _connectionColor = new Color(0.95f, 0.05f, 0.7f);
 
     public override void OnAwake()
     {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
+        _agentFactory = World.GetAspectFactory<AgentAspect>();
         _pursuers = World.Filter.
-            Extend<MobileAgentAspect>().
+            Extend<AgentAspect>().
+            With<AgentPathComponent>().
             With<TargetObserverComponent>().
             With<TargetPursuerComponent>().
             Build();
@@ -25,43 +26,43 @@ public sealed class PursueTargetSystem : CustomUpdateSystem
     {
         foreach(Entity e in _pursuers)
         {
-            var mobileAgent = _agentFactory.Get(e);
-            ref var actor = ref mobileAgent.Actor;
+            var agent = _agentFactory.Get(e);
+            ref var actor = ref agent.Actor;
             ref var target = ref e.GetComponent<TargetObserverComponent>();
 
             if (!World.TryGetEntity(target.id, out var targetEntity) || targetEntity.IsNullOrDisposed())
                 continue;
 
-            var body = mobileAgent.Body;
-            ref var agent = ref mobileAgent.Path;
+            var body = agent.Body;
+            ref var agentPath = ref e.GetComponent<AgentPathComponent>();
             Debug.DrawLine(body.transform.position, target.transform.position, _connectionColor);
 
             // This should be in a separate system!
             if (target.isInSight)
                 actor.lookTarget = target.transform.position;     // Look at the prey
-            else if (agent.pathNodeIdx >= 0 && agent.pathNodeIdx < agent.path.Length)
-                actor.lookTarget = agent.path[agent.pathNodeIdx];
+            else if (agentPath.pathNodeIdx >= 0 && agentPath.pathNodeIdx < agentPath.path.Length)
+                actor.lookTarget = agentPath.path[agentPath.pathNodeIdx];
             //else
             //    actor.lookTarget = WHERE???
 
 
-            float distance = (mobileAgent.Body.transform.position - target.transform.position).magnitude;
+            float distance = (agent.Body.transform.position - target.transform.position).magnitude;
             if (target.isInSight && distance <= actor.config.AttackRange)
             {
                 // Not coming too close
-                agent.destination = body.transform.position;
+                agentPath.destination = body.transform.position;
                 if (body.rigidbody.velocity.magnitude > 0.1f)
                     body.rigidbody.velocity *= 0.97f;
             }
             else
             {
                 // Just keep following the prey
-                agent.destination = target.transform.position;
+                agentPath.destination = target.transform.position;
                 if (targetEntity.Has<MovementComponent>())
                 {
                     var targetMovement = targetEntity.GetComponent<MovementComponent>();
-                    agent.destination.x += targetMovement.direction.x;
-                    agent.destination.z += targetMovement.direction.y;
+                    agentPath.destination.x += targetMovement.direction.x;
+                    agentPath.destination.z += targetMovement.direction.y;
                 }
             }
         }

--- a/Assets/Scripts/ECS/AI/Strategies/Pursue Target/PursuerToExplorerSystem.cs
+++ b/Assets/Scripts/ECS/AI/Strategies/Pursue Target/PursuerToExplorerSystem.cs
@@ -7,13 +7,13 @@ using Unity.IL2CPP.CompilerServices;
 [Il2CppSetOption(Option.DivideByZeroChecks, false)]
 public sealed class PursuerToExplorerSystem : CustomUpdateSystem
 {
-    AspectFactory<MobileAgentAspect> _agentFactory;
+    AspectFactory<AgentAspect> _agentFactory;
     Filter _pursuers;
 
     public override void OnAwake() {
-        _agentFactory = World.GetAspectFactory<MobileAgentAspect>();
+        _agentFactory = World.GetAspectFactory<AgentAspect>();
         _pursuers = World.Filter.
-            Extend<MobileAgentAspect>().
+            Extend<AgentAspect>().
             With<TargetObserverComponent>().
             With<TargetPursuerComponent>().
             Build();


### PR DESCRIPTION
Теперь персонажи мешают другим персонажам из союзных групп атаковать цель.
- Обход требуется только в том случае, если персонаж-препятствие принадлежит союзной группе (GroupRelation.NEUTRAL).
- Заслоняя собой цель, персонажи-препятствия триггерят выход из состояния атаки, что побуждает преследователей обходить их с целью дальнейшего преследования цели.
- Пока что возможно, что случайно перед прекращением атаки пресонаж-препятствие все-таки получит леща, потому что проверка видимости цели осуществляется всего двумя рэйкастами.